### PR TITLE
Update player.rb

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -61,6 +61,7 @@ module Spot
 
     def self.play_song(spotifyTrack)
       `./script/play-song #{spotifyTrack}`
+      sleep(0.5) #hack because it often sends back the info from the previously playing song
       self.playing
     end
 


### PR DESCRIPTION
Adds a hack so that self.play_song gives a moment for the track to switch before it gets the playing song information (for us it usually returns the info from the previously playing song even though it switches the song)