### PR TITLE
we had to put in a max after upgrading to el capitan

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -81,6 +81,9 @@ module Spot
 
     get '/query' do
       number = params[:limit]
+      if number.nil?
+        number = 20
+      end
       query = params[:q]
       tracks = Spotify.find_tracks(query, number)
       res = []


### PR DESCRIPTION
We upgraded the computer that runs this to El Capitan, and it started failing on any search (with or without a limit query). It seems like it was just overloading itself though.

When we added a cap of 20 (as in this PR), it worked fine, whether or not we had a limit. That is, it would default to 3 items if we didn't add a limit, and use whatever limit we specified if it did.

We tried 100 for this number and it failed in the same way as it did before there was a limit.

I'm a bit confused as to whether we should put this in spot.coffee instead of app.rb, or if it should be an ENV variable, but thought it would be good to discuss anyway?
